### PR TITLE
Ensure app background banner fills screen

### DIFF
--- a/App.swift
+++ b/App.swift
@@ -26,8 +26,11 @@ struct GraffNetApp: App {
 
   var body: some Scene {
     WindowGroup {
-      NavigationView { TagsMapView() }
-        .background(AppBackground())
+      ZStack {
+        AppBackground()
+        NavigationView { TagsMapView() }
+          .background(Color.clear)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- wrap the root navigation view in a ZStack so the banner background renders behind the app content
- keep the navigation view transparent so the banner artwork fills the available window space

## Testing
- not run (iOS project; tests require Xcode)

------
https://chatgpt.com/codex/tasks/task_e_68c94faaeedc832aa0a7ab0d289bf472